### PR TITLE
[18] - Refactorizar Test

### DIFF
--- a/notificationsManager/Operators/Tests/Feature/UpdateOperatorsCommandTest.php
+++ b/notificationsManager/Operators/Tests/Feature/UpdateOperatorsCommandTest.php
@@ -54,7 +54,6 @@ class UpdateOperatorsCommandTest extends TestCase
             ->expectsOutput($expectedResponse)
             ->assertExitCode(0);
 
-
         $this->assertDatabaseHas('operators', $operatorInDataBase);
     }
 

--- a/notificationsManager/Operators/Tests/OperatorTestDataBuilder.php
+++ b/notificationsManager/Operators/Tests/OperatorTestDataBuilder.php
@@ -58,6 +58,14 @@ class OperatorTestDataBuilder
         return $this;
     }
 
+    public function buildInvalidOperator(): Operator
+    {
+        return new Operator(
+            $this->id,
+            $this->customerId,
+        );
+    }
+
     public function build()
     {
         return new Operator(

--- a/notificationsManager/Operators/Tests/Unit/ApiOperatorsDataSourceTest.php
+++ b/notificationsManager/Operators/Tests/Unit/ApiOperatorsDataSourceTest.php
@@ -43,7 +43,7 @@ class ApiOperatorsDataSourceTest extends TestCase
     }
 
     #[Test]
-    public function failsToRetrieveOperators(): void
+    public function failsToGetOperators(): void
     {
         $this->client
             ->expects('get')

--- a/notificationsManager/Operators/Tests/Unit/DatabaseOperatorsDataSourceTest.php
+++ b/notificationsManager/Operators/Tests/Unit/DatabaseOperatorsDataSourceTest.php
@@ -31,4 +31,17 @@ class DatabaseOperatorsDataSourceTest extends TestCase
 
         $this->assertDatabaseHas('operators', $operatorTestDataBuilder->toDatabaseArray());
     }
+
+    #[Test]
+    public function failsToSaveOperators(): void
+    {
+        $operatorTestDataBuilder = new OperatorTestDataBuilder();
+        $operators = [];
+        $operators[] = $operatorTestDataBuilder->buildInvalidOperator();
+
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('Failed to update operators.');
+
+        $this->databaseOperatorsDataSource->save($operators);
+    }
 }


### PR DESCRIPTION
Retocar un poco los tests ya creados.
Añadir un test nuevo a DataBaseOperatorDataSourceTest y creado un método para instanciar operarios no válidos en operatorTestDataBuilder